### PR TITLE
Change to 'ruby-fifo' from 'fifo'

### DIFF
--- a/lib/fluent/plugin/in_named_pipe.rb
+++ b/lib/fluent/plugin/in_named_pipe.rb
@@ -11,7 +11,7 @@ module Fluent
     end
 
     def initialize
-      require 'fifo'
+      require 'ruby-fifo'
       super
     end
 

--- a/lib/fluent/plugin/out_named_pipe.rb
+++ b/lib/fluent/plugin/out_named_pipe.rb
@@ -10,7 +10,7 @@ module Fluent
     end
 
     def initialize
-      require 'fifo'
+      require 'ruby-fifo'
       super
     end
 

--- a/test/test_out_named_pipe.rb
+++ b/test/test_out_named_pipe.rb
@@ -1,7 +1,7 @@
 require_relative 'helper'
 require 'fluent/test'
 require 'fluent/plugin/out_named_pipe'
-require 'fifo'
+require 'ruby-fifo'
 
 Fluent::Test.setup
 


### PR DESCRIPTION
'fifo' will be seen as pointing to the https://github.com/sidbatra/fifo on https://rubygems.org.

---

I tried to use your plug from docker contaier. However, the following error message is output.

```
root@a314c02dae58:/# bundle install
...
Bundle complete! 4 Gemfile dependencies, 18 gems now installed.
Bundled gems are installed into .usr/local/bundle.

root@a314c02dae58:/# fluentd
2015-11-27 05:51:06 +0000 [info]: reading config file path="/etc/fluent/fluent.conf"
2015-11-27 05:51:06 +0000 [info]: starting fluentd-0.12.17
2015-11-27 05:51:06 +0000 [info]: gem 'fluentd' version '0.12.17'
2015-11-27 05:51:06 +0000 [info]: gem 'fluent-plugin-cloudwatch-logs' version '0.1.2'
2015-11-27 05:51:06 +0000 [info]: gem 'fluent-plugin-named_pipe' version '0.1.1'
2015-11-27 05:51:06 +0000 [info]: adding match pattern="foo.bar.**" type="named_pipe"
/usr/local/bundle/gems/fluent-plugin-named_pipe-0.1.1/lib/fluent/plugin/out_named_pipe.rb:13:in `require': cannot load such file -- fifo (LoadError)
        from /usr/local/bundle/gems/fluent-plugin-named_pipe-0.1.1/lib/fluent/plugin/out_named_pipe.rb:13:in `initialize'
        from /usr/local/bundle/gems/fluentd-0.12.17/lib/fluent/plugin.rb:128:in `new'
...
```

Used docker image is 'ruby:2.2.3'.

Gemfile

``` ruby
source "https://rubygems.org"

gem "ruby-fifo", :git => "https://github.com/shurizzle/ruby-fifo"
gem "fluentd"
gem "fluent-plugin-named_pipe"
gem "fluent-plugin-cloudwatch-logs"
```

fluent.conf

```
<source>
  type forward
</source>

<source>
  type   named_pipe
  tag    cwl.test
  path   /path/to/file
  format none
</source>

<match foo.bar.**>
  type   named_pipe
  path   /path/to/file
</match>

<match cwl.test>
  type               cloudwatch_logs
  log_group_name     aws/ec2/cwl-test
  auto_create_stream true
  use_tag_as_stream  true
</match>
```

It looks to move After replacement.

```
root@a314c02dae58:/# sed -i -e "s/require 'fifo'/require 'ruby-fifo'/g" /usr/local/bundle/gems/fluent-plugin-named_pipe-0.1.1/lib/fluent/plugin/*.rb
root@a314c02dae58:/# fluentd
2015-11-27 06:17:41 +0000 [info]: reading config file path="/etc/fluent/fluent.conf"
2015-11-27 06:17:41 +0000 [info]: starting fluentd-0.12.17
2015-11-27 06:17:41 +0000 [info]: gem 'fluentd' version '0.12.17'
2015-11-27 06:17:41 +0000 [info]: gem 'fluent-plugin-cloudwatch-logs' version '0.1.2'
2015-11-27 06:17:41 +0000 [info]: gem 'fluent-plugin-named_pipe' version '0.1.1'
2015-11-27 06:17:41 +0000 [info]: adding match pattern="foo.bar.**" type="named_pipe"
2015-11-27 06:17:41 +0000 [info]: adding match pattern="cwl.test" type="cloudwatch_logs"
2015-11-27 06:17:41 +0000 [info]: adding source type="forward"
2015-11-27 06:17:41 +0000 [info]: adding source type="named_pipe"
2015-11-27 06:17:41 +0000 [info]: using configuration file: <ROOT>
  <source>
    type forward
  </source>
  <source>
    type named_pipe
    tag cwl.test
    path /path/to/file
    format none
  </source>
  <match foo.bar.**>
    type named_pipe
    path /path/to/file
  </match>
  <match cwl.test>
    type cloudwatch_logs
    log_group_name aws/ec2/cwl-test
    auto_create_stream true
    use_tag_as_stream true
  </match>
</ROOT>
2015-11-27 06:17:41 +0000 [info]: listening fluent socket on 0.0.0.0:24224
```

私の環境でのみ起きてることなのかもしれませんが、、
