### PR TITLE
readline keep throwing TypeError exception

### DIFF
--- a/fluent-plugin-named_pipe.gemspec
+++ b/fluent-plugin-named_pipe.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_runtime_dependency "fluentd", ">= 0.10.58"
-  s.add_runtime_dependency "ruby-fifo", "0.0.1"
+  s.add_runtime_dependency "ruby-fifo"
   if RUBY_PLATFORM =~ /mswin|mingw/i
     s.add_runtime_dependency "win32-pipe"
   else

--- a/lib/fluent/plugin/in_named_pipe.rb
+++ b/lib/fluent/plugin/in_named_pipe.rb
@@ -53,6 +53,7 @@ module Fluent
           else
             log.warn "Pattern not match: #{line.inspect}"
           end
+        rescue TypeError
         rescue => e
           log.error "in_named_pipe: unexpected error", :error_class => e.class, :error => e.to_s
           log.error_backtrace


### PR DESCRIPTION
fix(TypeError): when fifo is empty, readline keep throwing TypeError exception.  and the latest ```ruby-fifo:0.1.0``` seems fine. 

```
2017-01-27 11:15:07 -0800 [error]: in_named_pipe: unexpected error error_class=TypeError error="no implicit conversion of nil into String"
  2017-01-27 11:15:07 -0800 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/ruby-fifo-0.0.1/lib/fifo.rb:68:in `readline'
  2017-01-27 11:15:07 -0800 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluent-plugin-named_pipe-0.1.2/lib/fluent/plugin/in_named_pipe.rb:49:in `run'
```