### PR TITLE
Use own fifo library

### DIFF
--- a/fluent-plugin-named_pipe.gemspec
+++ b/fluent-plugin-named_pipe.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_runtime_dependency "fluentd", ">= 0.10.58"
-  s.add_runtime_dependency "ruby-fifo", "0.0.1"
   if RUBY_PLATFORM =~ /mswin|mingw/i
     s.add_runtime_dependency "win32-pipe"
   else

--- a/fluent-plugin-named_pipe.gemspec
+++ b/fluent-plugin-named_pipe.gemspec
@@ -17,11 +17,8 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_runtime_dependency "fluentd", ">= 0.10.58"
-  if RUBY_PLATFORM =~ /mswin|mingw/i
-    s.add_runtime_dependency "win32-pipe"
-  else
-    s.add_runtime_dependency "mkfifo"
-  end
+  s.add_runtime_dependency "mkfifo"
+
   s.add_development_dependency "rake"
   s.add_development_dependency "test-unit"
   s.add_development_dependency "pry"

--- a/lib/fluent/plugin/fifo.rb
+++ b/lib/fluent/plugin/fifo.rb
@@ -3,7 +3,9 @@ require 'mkfifo'
 
 class Fifo
   include Forwardable
-  
+
+  READ_TIMEOUT = 1
+
   class Pipe < ::File
     alias :orig_write :write
     def write(*args)
@@ -33,7 +35,7 @@ class Fifo
   end
 
   def readline
-    res = IO.select([@pipe], [], [], 1)
+    res = IO.select([@pipe], [], [], READ_TIMEOUT)
     return nil if res.nil?
     
     while nil == (idx = @buf.index("\n")) do

--- a/lib/fluent/plugin/fifo.rb
+++ b/lib/fluent/plugin/fifo.rb
@@ -33,6 +33,9 @@ class Fifo
   end
 
   def readline
+    res = IO.select([@pipe], [], [], 1)
+    return nil if res.nil?
+    
     while nil == (idx = @buf.index("\n")) do
       tmp = ''
       begin

--- a/lib/fluent/plugin/fifo.rb
+++ b/lib/fluent/plugin/fifo.rb
@@ -29,26 +29,20 @@ class Fifo
 
   def open
     m = {:r => 'r+', :w => 'w+'}[@mode]
-    # p "open %s %s" % [@file_path, m]
     @pipe = Pipe.open(@file_path, m)
   end
 
   def readline
     while nil == (idx = @buf.index("\n")) do
-      # while nil == (tmp = self.read(1)) do
       tmp = ''
-      while true
-        begin
-          s = @pipe.sysread(0xffff, tmp)
-          p s
-        rescue EOFError => e
-          # reopen
-          @pipe.close
-          @pipe.open
-        end
+      begin
+        s = @pipe.sysread(0xffff, tmp)
+        @buf << s
+      rescue EOFError => e
+        # reopen
+        @pipe.close
+        @pipe.open
       end
-
-      @buf << tmp
     end
 
     line = @buf[0, idx + 1]

--- a/lib/fluent/plugin/fifo.rb
+++ b/lib/fluent/plugin/fifo.rb
@@ -1,0 +1,54 @@
+require 'forwardable'
+
+class Fifo
+  include Forwardable
+  
+  class Pipe < ::File
+    alias :orig_write :write
+    def write(*args)
+      orig_write(*args)
+      flush
+    end
+  end
+  
+  def initialize(file_path, mode = :r)
+    if !File.exist?(file_path)
+      File.mkfifo(file_path)
+      File.chmod(0666, file_path)
+    end
+
+    @file_path = file_path
+    @mode = mode
+    self.open
+
+    def_delegators :@pipe, :read, :write, :close
+    
+    @buf = ''
+  end
+
+  def open
+    m = {:r => 'r+', :w => 'w+'}[@mode]
+    # p "open %s %s" % [@file_path, m]
+    @pipe = Pipe.open(@file_path, m)
+  end
+
+  def readline
+    while nil == (idx = @buf.index("\n")) do
+      while nil == (tmp = self.read(1)) do
+      # while nil == (tmp = self.gets) do
+        p '* nil'
+        p tmp
+        # reopen
+        @pipe.close
+        @pipe.open
+      end
+
+      @buf << tmp
+    end
+
+    line = @buf[0, idx + 1]
+    @buf = @buf[idx + 1, @buf.length - line.length]
+    return line
+  end
+
+end

--- a/lib/fluent/plugin/fifo.rb
+++ b/lib/fluent/plugin/fifo.rb
@@ -35,10 +35,17 @@ class Fifo
 
   def readline
     while nil == (idx = @buf.index("\n")) do
-      while nil == (tmp = self.read(1)) do
-        # reopen
-        @pipe.close
-        @pipe.open
+      # while nil == (tmp = self.read(1)) do
+      tmp = ''
+      while true
+        begin
+          s = @pipe.sysread(0xffff, tmp)
+          p s
+        rescue EOFError => e
+          # reopen
+          @pipe.close
+          @pipe.open
+        end
       end
 
       @buf << tmp

--- a/lib/fluent/plugin/fifo.rb
+++ b/lib/fluent/plugin/fifo.rb
@@ -1,4 +1,5 @@
 require 'forwardable'
+require 'mkfifo'
 
 class Fifo
   include Forwardable

--- a/lib/fluent/plugin/fifo.rb
+++ b/lib/fluent/plugin/fifo.rb
@@ -36,9 +36,6 @@ class Fifo
   def readline
     while nil == (idx = @buf.index("\n")) do
       while nil == (tmp = self.read(1)) do
-      # while nil == (tmp = self.gets) do
-        p '* nil'
-        p tmp
         # reopen
         @pipe.close
         @pipe.open

--- a/lib/fluent/plugin/in_named_pipe.rb
+++ b/lib/fluent/plugin/in_named_pipe.rb
@@ -54,6 +54,11 @@ module Fluent
       while @running
         begin
           line = @pipe.readline # blocking
+          if line.nil?
+            p 'timeout'
+            next
+          end
+          
           @parser.parse(line) do |time, record|
             if time and record
               router.emit(@tag, time, record)

--- a/lib/fluent/plugin/in_named_pipe.rb
+++ b/lib/fluent/plugin/in_named_pipe.rb
@@ -54,10 +54,7 @@ module Fluent
       while @running
         begin
           line = @pipe.readline # blocking
-          if line.nil?
-            p 'timeout'
-            next
-          end
+          next if line.nil?
           
           @parser.parse(line) do |time, record|
             if time and record

--- a/lib/fluent/plugin/in_named_pipe.rb
+++ b/lib/fluent/plugin/in_named_pipe.rb
@@ -18,7 +18,7 @@ module Fluent
     end
 
     def initialize
-      require 'fifo'
+      require_relative 'fifo'
       super
     end
 
@@ -26,7 +26,7 @@ module Fluent
       super
 
       begin
-        pipe = Fifo.new(@path, :r, :nowait)
+        pipe = Fifo.new(@path, :r)
         pipe.close # just to try open
       rescue => e
         raise ConfigError, "#{e.class}: #{e.message}"
@@ -49,7 +49,7 @@ module Fluent
     end
 
     def run
-      @pipe = Fifo.new(@path, :r, :wait)
+      @pipe = Fifo.new(@path, :r)
 
       while @running
         begin

--- a/lib/fluent/plugin/out_named_pipe.rb
+++ b/lib/fluent/plugin/out_named_pipe.rb
@@ -10,7 +10,7 @@ module Fluent
     end
 
     def initialize
-      require 'fifo'
+      require_relative 'fifo'
       super
     end
 
@@ -18,7 +18,7 @@ module Fluent
       super
 
       begin
-        @pipe = Fifo.new(@path, :w, :nowait)
+        @pipe = Fifo.new(@path, :w)
       rescue => e
         raise ConfigError, "#{e.class}: #{e.message}"
       end

--- a/test/test_in_named_pipe.rb
+++ b/test/test_in_named_pipe.rb
@@ -53,6 +53,27 @@ class NamedPipeInputTest < Test::Unit::TestCase
         assert_equal({"foo"=>"bar\n"}, record)
       end
     end
+
+    
+    test 'fragmented emit' do
+      d = create_driver(CONFIG)
+      d.run {
+        pipe = Fifo.new(TEST_PATH, :w)
+        pipe.write "fo"
+        sleep 0.2
+        pipe.write "o:ba"
+        sleep 0.2
+        pipe.write "r\n"
+      }
+
+      emits = d.emits
+      emits.each do |tag, time, record|
+        assert_equal("named_pipe", tag)
+        assert_equal({"foo"=>"bar\n"}, record)
+      end
+    end
+
+    
   end
 end
 

--- a/test/test_in_named_pipe.rb
+++ b/test/test_in_named_pipe.rb
@@ -43,7 +43,7 @@ class NamedPipeInputTest < Test::Unit::TestCase
     test 'read and emit' do
       d = create_driver(CONFIG)
       d.run {
-        pipe = Fifo.new(TEST_PATH, :w, :nowait)
+        pipe = Fifo.new(TEST_PATH, :w)
         pipe.write "foo:bar\n"
       }
 

--- a/test/test_out_named_pipe.rb
+++ b/test/test_out_named_pipe.rb
@@ -1,7 +1,7 @@
 require_relative 'helper'
 require 'fluent/test'
 require 'fluent/plugin/out_named_pipe'
-require 'fifo'
+require 'fluent/plugin/fifo'
 
 Fluent::Test.setup
 
@@ -48,7 +48,7 @@ class NamedPipeOutputTest < Test::Unit::TestCase
     test 'reader is waiting' do
       readline = nil
       thread = Thread.new {
-        pipe = Fifo.new(TEST_PATH, :r, :wait)
+        pipe = Fifo.new(TEST_PATH, :r)
         readline = pipe.readline
       }
 


### PR DESCRIPTION
## Background

- `ruby-fifo` gem does not handle return value from File.read properly. Then it raises Exception and stop if File.read receives EOF
- `ruby-fifo` read from named pipe byte by byte. It may cause performance issue
- The gem looks like not maintained

## Changes

- Create `lib/fluent/plugin/fifo.rb` as own fifo library
- Use`IO.sysread` instead of `File.read` to avoid read blocking
- Add error handling for EOF