### PR TITLE
Buffering bug fix.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ coverage
 .yardoc
 .ruby-version
 pkg/*
+.idea

--- a/lib/fluent/plugin/named_pipe/fifo.rb
+++ b/lib/fluent/plugin/named_pipe/fifo.rb
@@ -31,6 +31,12 @@ module Fluent
       end
 
       def readline
+        if nil != (idx = @buf.index("\n"))
+          line = @buf[0, idx + 1]
+          @buf = @buf[idx + 1, @buf.length - line.length]
+          return line
+        end
+
         res = IO.select([@pipe], [], [], READ_TIMEOUT)
         return nil if res.nil?
 


### PR DESCRIPTION
Hi,
There is a bug in the readline buffering.  If multiple line buffered, only the first line is being consumed, subsequent calls to readline wont consume the buffer until more bufferable input provided as the buffer consuming happens only after the select() and on select timeout, the readline returns with nil.

Please consider merging this PR.

Thanks,
Daniel